### PR TITLE
fix repo name to try to pick up translations

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -1,5 +1,5 @@
 {
-    "name": "minecraft-hoc22",
+    "name": "hoc22-ts",
     "version": "0.4.4",
     "dependencies": {
         "core": "*",


### PR DESCRIPTION
Should be fix for translations not showing up

<img width="511" alt="image" src="https://user-images.githubusercontent.com/5615930/202816000-5ead5099-03c7-4eb8-9793-ad0d32e4a25e.png">

(I'm assuming sort just isn't translated yet since everything else appears to be)

This field should always match repo name for consistency / avoid weird edge cases~